### PR TITLE
add first sample to ingest container based models

### DIFF
--- a/upload-model-containers.ipynb
+++ b/upload-model-containers.ipynb
@@ -1,0 +1,706 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "rest_docker_bank_churn.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NZEePHrzGOlC"
+      },
+      "source": [
+        "# Importing an ML model container into Fiddler\n",
+        "\n",
+        "---\n",
+        "\n",
+        "Packaging ML models and their dependencies as a container where the `/predict` endpoint is exposed via RESTful APIs is not uncommon. Such container based models can be imported as-is into Fiddler and then can be used for monitoring or explanations.\n",
+        "\n",
+        "## RESTful API for an ML model\n",
+        "The model is trained and saved, so what's next? \n",
+        "\n",
+        "For the purpose of this exercise, we can use the Random Forest based sklearn model created in the `bank_churn` sample.*italicized text*"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "E0PD5W71xrD7"
+      },
+      "source": [
+        "%cd\n",
+        "!wget -P bank-churn https://github.com/fiddler-labs/fiddler-samples/raw/master/content_root/samples/bank_churn/bank_churn/model.pkl \n",
+        "!wget -P bank-churn https://raw.githubusercontent.com/fiddler-labs/fiddler-samples/master/content_root/samples/bank_churn/bank_churn/churn_random_forest.py"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b2nM_miLxrow"
+      },
+      "source": [
+        "## Expose model predictions as an API\n",
+        "One of the ways the model can be used by various entities is via APIs. Of the various different types of APIs, RESTful APIs are quite flexible and user friendly.\n",
+        "\n",
+        "As an example, we can use the popular [Flask](https://flask.palletsprojects.com/en/1.1.x/quickstart/#quickstart) web application framework to expose endpoints such as `/predict` which can be used to access the model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KL1mK6Xp-pjC"
+      },
+      "source": [
+        "## Create RESTful APIs for the `bank_churn` model using Flask"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8UhRdRQ8uIK8"
+      },
+      "source": [
+        "%%writefile bank-churn/server.py\n",
+        "\n",
+        "#\n",
+        "# server.py: A python script to expose the bank_churn model.pkl via REST API.\n",
+        "#\n",
+        " \n",
+        "import os\n",
+        "import pickle\n",
+        " \n",
+        "import flask\n",
+        "from churn_random_forest import RFPredictor\n",
+        " \n",
+        "PACKAGE_DIR = os.path.dirname(__file__)\n",
+        " \n",
+        "# load the bank_churn model.pkl.\n",
+        "model = RFPredictor(PACKAGE_DIR, output_column=['probability_churned'])\n",
+        " \n",
+        " \n",
+        "def init_server():\n",
+        "    app = flask.Flask(__name__)\n",
+        " \n",
+        "    @app.route('/health', methods=['GET'])\n",
+        "    def health():\n",
+        "      # return the health of the model.\n",
+        "        return 'OK'\n",
+        " \n",
+        "    @app.route('/predict', methods=['POST'])\n",
+        "    def predict():\n",
+        "      # load the input data from the flask request which is\n",
+        "      # a python pickle.\n",
+        "        df = pickle.loads(flask.request.data)\n",
+        "        try:\n",
+        "            # run a prediction on the model object using the\n",
+        "            # input dataframe.\n",
+        "            pred_obj = model.predict(df)\n",
+        "        except Exception as e:\n",
+        "            raise RuntimeError(\n",
+        "                f'Model and input loaded, but prediction failed. '\n",
+        "                f'Is your input correct? {e}'\n",
+        "            )\n",
+        "        # return the pickled prediction as a response.\n",
+        "        return flask.Response(\n",
+        "            pickle.dumps(pred_obj), mimetype='application/octet-stream'\n",
+        "        )\n",
+        " \n",
+        "    # return the Flask app.\n",
+        "    return app\n",
+        " \n",
+        " \n",
+        "if __name__ == '__main__':\n",
+        "    # purposely running Flask in debug mode. Do not do this in production.\n",
+        "    init_server().run(host='0.0.0.0', port=5101, threaded=False, debug=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "blncy1JmuQFd"
+      },
+      "source": [
+        "\n",
+        "`server.py` code above sets up RESTful API around the `bank_churn` model and the API is served by Flask app on port 5101. By the way, this example uses Flask in debug mode and is not meant for production workflows."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XjHwERbfR_kB"
+      },
+      "source": [
+        "## Package the model artifacts, the API server and the dependencies\n",
+        "\n",
+        "There's a few things that are needed to make this model and API work reliably in different environments like laptops, Linux, Mac, kubernetes etc. To achieve that portability we need to package the model artifacts and `server.py` along with their dependencies (python modules and packages etc). So, the next step is to package this model into a container thus making it a microservice.\n",
+        "\n",
+        "Let's use a dockerfile to describe the recipe for the container."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TDzWi9NNu_5L"
+      },
+      "source": [
+        "%%writefile bank-churn/Dockerfile\n",
+        "\n",
+        "\n",
+        "#\n",
+        "# Dockerfile: package the model artifacts into a container\n",
+        "#\n",
+        "\n",
+        "# Use a python-3 based base image.\n",
+        "FROM python:3.7\n",
+        "\n",
+        "# Set /app as the working directory\n",
+        "WORKDIR /app\n",
+        "\n",
+        "# Install the dependencies\n",
+        "RUN pip install --upgrade pip \\\n",
+        "    && pip install scikit-learn==0.21.2 flask==1.1.1 pandas==0.25.1 joblib==0.14.0\n",
+        "\n",
+        "# Copy the relevant model artifacts into WORKDIR\n",
+        "COPY churn_random_forest.py /app/churn_random_forest.py\n",
+        "COPY model.pkl /app/model.pkl\n",
+        "\n",
+        "# Copy the API server script to WORKDIR\n",
+        "COPY server.py /app/server.py\n",
+        "\n",
+        "# Expose the port 5101 on the container\n",
+        "EXPOSE 5101\n",
+        "\n",
+        "# Run server.py\n",
+        "CMD [ \"python\", \"./server.py\" ]"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "L2dCH1IcvMbP"
+      },
+      "source": [
+        "Given this `dockerfile`, we can now build a container image that packages up the model artifacts, dependencies and flask server script.\n",
+        "\n",
+        "The container image is built using:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9D2CwPOu7gcR"
+      },
+      "source": [
+        "%cd bank-churn/"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "F3rDGk7wvQy2"
+      },
+      "source": [
+        "!docker build -t examples:bank-churn-1.0 ."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yT0HJT6_hhPx"
+      },
+      "source": [
+        "%cd"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iF6q-UuXvV0i"
+      },
+      "source": [
+        "Once the build is done, the image details can be seen by running:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MJzYh7BNvbcC"
+      },
+      "source": [
+        "!docker images"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NjqkIOievfq-"
+      },
+      "source": [
+        "Thus built container can be run to make sure the container process starts up properly and the APIs are accessible.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jPFqsSWpvizL"
+      },
+      "source": [
+        "!docker run -d --name bank-churn -p 5101:5101 examples:bank-churn-1.0"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t_xd2Q8tvmjT"
+      },
+      "source": [
+        "If all goes well, the `bank_churn` container should now be started up and ready to serve requests on port 5101 and you should be able to inspect the logs on the container using:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FKhCRfwivpSW"
+      },
+      "source": [
+        "!docker logs bank-churn"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6zp_sWKYvtDd"
+      },
+      "source": [
+        "This container image can now be pushed onto a container image registry. Once that's done, the image can be used by others either as a container or as a pod on kubernetes.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "17TJEpTsvwJN"
+      },
+      "source": [
+        "!docker tag examples:bank-churn-1.0 quay.io/fiddler/examples:bank-churn-1.0"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "E_t2r7tIv35N"
+      },
+      "source": [
+        "!docker login -u fiddler -p <password> quay.io/fiddler"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zCUjLKKRv6Uv"
+      },
+      "source": [
+        "!docker push quay.io/fiddler/examples:bank-churn-1.0"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bIGafPW6CPPp"
+      },
+      "source": [
+        "## Upload and Serve `bank_churn` model\n",
+        "\n",
+        "The model is packaged, tagged and pushed onto a registry like dockerhub, ECR, quay etc and is ready to be used. \n",
+        "\n",
+        "We will go through the steps needed to ingest that model into Fiddler and use it for predictions, explanations and monitoring."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2l5FNiaFEB-o"
+      },
+      "source": [
+        "### Initialize Fiddler Client\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vQVlUgoBaEVZ"
+      },
+      "source": [
+        "!pip3 install fiddler-client"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9pdJhJnvEJpt"
+      },
+      "source": [
+        "import fiddler as fdl\n",
+        "import pathlib\n",
+        "import shutil\n",
+        "\n",
+        "client = fdl.FiddlerApi()\n",
+        "\n",
+        "PROJECT_ID = 'bank-churn'\n",
+        "DATASET_ID = 'bank-churn'\n",
+        "MODEL_ID = 'bank-churn'\n",
+        "\n",
+        "# create a working dir to save the schema\n",
+        "MODEL_DIR = pathlib.Path(MODEL_ID)\n",
+        "shutil.rmtree(MODEL_DIR, ignore_errors=True)\n",
+        "MODEL_DIR.mkdir()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DXwRKkL9EN7j"
+      },
+      "source": [
+        "### Load Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bwT8QP42ESZw"
+      },
+      "source": [
+        "import pandas as pd\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "\n",
+        "df = pd.read_csv('https://raw.githubusercontent.com/fiddler-labs/fiddler-samples/be88d600bb87c33b7b49528089adca8b4a0c867c/content_root/samples/datasets/bank_churn/dataset.csv')\n",
+        "df = df.reset_index(drop=True)\n",
+        "\n",
+        "train, test = train_test_split(df, test_size=0.3)\n",
+        "df_info = fdl.DatasetInfo.from_dataframe(df, display_name='bank-churn Dataset')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wIMB0Y__EoNy"
+      },
+      "source": [
+        "### Upload Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2irWksDVErwc"
+      },
+      "source": [
+        "if 'bank_churn' not in client.list_datasets():\n",
+        "    upload_result = client.upload_dataset(\n",
+        "        dataset={'train': train, 'test': test},\n",
+        "        dataset_id='bank_churn',\n",
+        "        info=df_info)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ILpgtw4ZEy0Y"
+      },
+      "source": [
+        "### Create and Save Model Schema"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TlOB-BE4E2KB"
+      },
+      "source": [
+        "target = 'Churned'\n",
+        "feature_columns = list(df.drop(columns=['Churned']).columns)\n",
+        "\n",
+        "model_info = fdl.ModelInfo.from_dataset_info(\n",
+        "    dataset_info=client.get_dataset_info('bank_churn'),\n",
+        "    target=target, \n",
+        "    features=feature_columns,\n",
+        "    display_name='bank_churn model',\n",
+        "    description='scikit-learn Random Forest model based on Kaggle Bank Customer Churn data'\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "NbsvSsvGK3Mu"
+      },
+      "source": [
+        "import yaml\n",
+        "\n",
+        "# save model schema\n",
+        "with open(MODEL_DIR / 'model.yaml', 'w') as yaml_file:\n",
+        "    yaml.dump({'model': model_info.to_dict()}, yaml_file)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "soxYRB7DM3w8"
+      },
+      "source": [
+        "### `package.py` Wrapper\n",
+        "\n",
+        "A wrapper is needed between Fiddler and the model. This wrapper can be used to translate the inputs and outputs to fit what the model expects and what Fiddler is able to consume.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "H0pYy_DHPps0"
+      },
+      "source": [
+        "%%writefile bank-churn/package.py\n",
+        "\n",
+        "\n",
+        "\"\"\"\n",
+        "python wrapper to transform the input and outputs of the model.\n",
+        "\"\"\"\n",
+        "import logging\n",
+        "import os\n",
+        "import pickle\n",
+        "from typing import NamedTuple\n",
+        "\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import requests\n",
+        "\n",
+        "LOG = logging.getLogger(__name__)\n",
+        "\n",
+        "\n",
+        "class ModelId(NamedTuple):\n",
+        "    \"\"\"Uniquely identifies a model.\"\"\"\n",
+        "\n",
+        "    org_name: str\n",
+        "    project_name: str\n",
+        "    model_name: str\n",
+        "\n",
+        "\n",
+        "class Predictor:\n",
+        "    \"\"\"\n",
+        "    Handles running predictions on an containerized model that exposes the\n",
+        "    `/predict` endpoint.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    # If an external endpoint is defined at `MODEL_ENDPOINT` use that.\n",
+        "    # Otherwise use the ingress.\n",
+        "    ENDPOINT = os.environ.get('MODEL_ENDPOINT', 'http://ingress-nginx.ingress-nginx')\n",
+        "\n",
+        "    def __init__(self, model_id: ModelId, model_info):\n",
+        "        \"\"\"\n",
+        "        Initialize the mode predictor.\n",
+        "\n",
+        "        model: the model_id, a NamedTuple which contains the org, project and\n",
+        "        model to uniquely identify the model.\n",
+        "        model_info: the model schema.\n",
+        "        \"\"\"\n",
+        "        self.model_id = model_id\n",
+        "        self.model_info = model_info\n",
+        "\n",
+        "    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:\n",
+        "        \"\"\"\n",
+        "        Given the input_df, transform it to the input the model expects and\n",
+        "        call the `/predict` endpoint of the model.\n",
+        "        \"\"\"\n",
+        "        try:\n",
+        "            url = '/'.join([self.ENDPOINT, 'predict', *self.model_id])\n",
+        "            res = requests.post(url, data=pickle.dumps(input_df))\n",
+        "            res.raise_for_status()\n",
+        "        except Exception as ex:\n",
+        "            try:\n",
+        "                error_info = res.json()\n",
+        "            except Exception:\n",
+        "                error_info = None\n",
+        "            raise RuntimeError(\n",
+        "                f'Model execution failed for {self.model_id}.\\n'\n",
+        "                f'Exception:{ex}\\nServer Exception:{error_info}'\n",
+        "            )\n",
+        "\n",
+        "        try:\n",
+        "            pred_obj = pickle.loads(res.content)\n",
+        "        except Exception as ex:\n",
+        "            raise RuntimeError(\n",
+        "                f'Model execution call was successful, but '\n",
+        "                f'failed to un-pickle the prediction. {ex}'\n",
+        "            )\n",
+        "\n",
+        "        try:\n",
+        "            if str(type(pred_obj)).endswith(\"pandas.core.frame.DataFrame'>\"):\n",
+        "                pred_df = pred_obj\n",
+        "            else:\n",
+        "                pred_array = np.array(pred_obj)\n",
+        "                if pred_array.ndim == 1:\n",
+        "                    pred_array = pred_array[:, np.newaxis]\n",
+        "                pred_df = pd.DataFrame(pred_array)\n",
+        "            pred_df.columns = self.model_info.get_output_names()\n",
+        "        except Exception as ex:\n",
+        "            pred_obj_excerpt = repr(pred_obj)[:1_000]\n",
+        "            raise RuntimeError(\n",
+        "                f'Model execution call and result unpickling were successful, '\n",
+        "                f' but unable to massage results into a dataframe of model '\n",
+        "                f'predictions.\\nException: {ex}\\nReturned object type: '\n",
+        "                f'{type(pred_obj)}.\\nObject: {pred_obj_excerpt}'\n",
+        "            )\n",
+        "\n",
+        "        return pred_df\n",
+        "\n",
+        "\n",
+        "def get_predictor(model_id, model_info):\n",
+        "    \"\"\"\n",
+        "    `get_predictor(model_id, model_info)` is the required hook that's called by\n",
+        "    the executor-service to get to the `Predictor`.\n",
+        "    \"\"\"\n",
+        "    return Predictor(model_id, model_info)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0j0dojcPQ-t-"
+      },
+      "source": [
+        "### Ingest and Register the model container with **Fiddler**\n",
+        "\n",
+        "Use the container image from the registry and specify the resources required as a part of the call into Fiddler.\n",
+        "\n",
+        "`upload_model_package` when given the parameters like `image`, `deployment_type` etc, creates a set of kubernetes objects like a deployment, service, ingress etc in the background.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_aU7KafbRHbG"
+      },
+      "source": [
+        "# create a project for this model, if needed.\n",
+        "if PROJECT_ID not in client.list_projects():\n",
+        "    client.create_project(PROJECT_ID)\n",
+        "\n",
+        "image = \"quay.io/fiddler/examples@sha256:8a808fcfb8a4e9f161556d77d9252c1af8fe4fa3d70cfdc044f8894be186726a\"\n",
+        "client.upload_model_package(\n",
+        "    artifact_path=pathlib.Path(\n",
+        "        MODEL_DIR\n",
+        "    ),  # expects a model.yaml, package.py, and model.pkl\n",
+        "    project_id=PROJECT_ID,\n",
+        "    model_id=MODEL_ID,\n",
+        "    deployment_type='predictor',  # when the model just exposes a predict endpoint\n",
+        "    port=5101,\n",
+        "    cpus=1,\n",
+        "    memory='512Mi',\n",
+        "    image_uri=image,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YG_7K3N1SvQ6"
+      },
+      "source": [
+        "### Run Predictions on the Model\n",
+        "\n",
+        "Once the model is ingested and deployed on Fiddler, we should be able to use it for predictions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Je2nr1UwS-Hk"
+      },
+      "source": [
+        "predictions = client.run_model(\n",
+        "    project_id=PROJECT_ID,\n",
+        "    model_id=MODEL_ID,\n",
+        "    df=test.head(10)\n",
+        ")\n",
+        "predictions"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_nX20qZ9QMr0"
+      },
+      "source": [
+        "explanations = client.run_explanation(\n",
+        "    project_id=PROJECT_ID,\n",
+        "    model_id=MODEL_ID,\n",
+        "    df=test.head(10),\n",
+        "    dataset_id='bank_churn'\n",
+        ")\n",
+        "explanations"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y4bcKGHBTTuG"
+      },
+      "source": [
+        "## That's All Folks!"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This example describes how to add a RESTful API to expose the predict
method of a model and then package it up into a container image, upload
it to a registry and finally ingesting that container into Fiddler for
predictions, explanations and monitoring.