### PR TITLE
`jovyan` user needs to assume the UID/GID of the logged in user

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,9 @@ SHELL := /bin/bash
 SERVICE_NAME=fiddler_samples
 FIDDLER_DIR:=$(shell cd . && pwd)
 
+UID:=$(shell id -u)
+GID:=$(shell id -g)
+
 default: build stop run logs
 
 build:
@@ -14,7 +17,7 @@ logs:
 	docker logs fiddler_samples
 
 run:
-	docker run --rm -d -p 7100:7100 -v ${FIDDLER_DIR}/content_root:/app/fiddler_samples --name=fiddler_samples fiddler_samples:latest
+	docker run --rm -d --user ${UID}:${GID} --group-add users -p 8888:7100 -v ${FIDDLER_DIR}/content_root:/app/fiddler_samples --name=fiddler_samples fiddler_samples:latest
 
 ssh:
 	docker exec -it fiddler_samples /bin/bash

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ logs:
 	docker logs fiddler_samples
 
 run:
-	docker run --rm -d --user ${UID}:${GID} --group-add users -p 8888:7100 -v ${FIDDLER_DIR}/content_root:/app/fiddler_samples --name=fiddler_samples fiddler_samples:latest
+	docker run --rm -d --user ${UID}:${GID} --group-add users -p 7100:7100 -v ${FIDDLER_DIR}/content_root:/app/fiddler_samples --name=fiddler_samples fiddler_samples:latest
 
 ssh:
 	docker exec -it fiddler_samples /bin/bash


### PR DESCRIPTION
    `jovyan` user needs to use the UID/GID of the logged in user
    
    `jovyan` user assumes UID: 1000 and GID: 1000 as of now. However, that
    will not work (as seen with one of the customer working sessions) when
    the logged in user is not using 1000:1000 and downloads fiddler-samples,
    since the files will be stored using the UID:GID of the logged in user.
    
    The best practice here is for `jovyan` user to assume the UID:GID of the
    logged in user.