### PR TITLE
Adding a reminder to use https in the quick start guide

### DIFF
--- a/content_root/tutorial/quickstart/Fiddler_Quick_Start_Guide.ipynb
+++ b/content_root/tutorial/quickstart/Fiddler_Quick_Start_Guide.ipynb
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "URL = #"
+    "URL = '**UPDATE_ME**' # Make sure to include the full URL (including https://)."
    ]
   },
   {


### PR DESCRIPTION
1. **Context:** I had some issues with this because I didn't add https. Wanted to add a reminder that people should use the full URL.
2. Changes:
  a. Remind people to use https:// or the full URL.
  b. Add a full stop to the steps.
3. ****I'm mostly making this to get familiar with the PR flow. Feel free to deny it.****