### PR TITLE
Change lookalike to surrogate

### DIFF
--- a/content_root/tutorial/quickstart/Fiddler_Quick_Start_Guide.ipynb
+++ b/content_root/tutorial/quickstart/Fiddler_Quick_Start_Guide.ipynb
@@ -360,9 +360,9 @@
     "id": "azE_UU6HE6vW"
    },
    "source": [
-    "This information alows Fiddler to build a **lookalike model** on the backend that can provide more insight into your model's performance.\n",
+    "This information alows Fiddler to build a **surrogate model** on the backend that can provide more insight into your model's performance.\n",
     "  \n",
-    "*For more information on lookalike models, [click here](https://docs.fiddler.ai/pages/user-guide/data-science-concepts/explainability/lookalike-models/).*\n",
+    "*For more information on surrogate models, [click here](https://docs.fiddler.ai/docs/surrogate-models).*\n",
     "\n",
     "\n",
     "---\n",


### PR DESCRIPTION
Changing the terminology to "surrogate model" from "lookalike model" in the quick start.