### PR TITLE
added a cell to save model.yaml that was missing form the quick start

### DIFF
--- a/content_root/tutorial/quickstart/Fiddler_QuickStart_Model_Add_Artifact.ipynb
+++ b/content_root/tutorial/quickstart/Fiddler_QuickStart_Model_Add_Artifact.ipynb
@@ -380,6 +380,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a72cfe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "# save model schema\n",
+    "with open('model/model.yaml', 'w') as yaml_file:\n",
+    "    yaml.dump({'model': model_info.to_dict()}, yaml_file)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "83bb1f43-dd33-473d-b788-086cbbb3d10d",
    "metadata": {
@@ -706,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While working on the NRI PoV I noticed this notebook is missing a step to save the YAML file. I just added that cell in right after the model info object is created. 